### PR TITLE
fix: remove mapped service alias if no longers exists

### DIFF
--- a/metanetworks/resource_mapped_service_alias.go
+++ b/metanetworks/resource_mapped_service_alias.go
@@ -3,6 +3,7 @@ package metanetworks
 import (
 	"errors"
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -63,6 +64,24 @@ func resourceMappedServiceAliasCreate(d *schema.ResourceData, m interface{}) err
 }
 
 func resourceMappedServiceAliasRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*Client)
+
+	mappedServiceID := d.Get("mapped_service_id").(string)
+	alias := d.Get("alias").(string)
+
+	var networkElement *NetworkElement
+	networkElement, err := client.GetNetworkElement(mappedServiceID)
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < len(networkElement.Aliases); i++ {
+		if networkElement.Aliases[i] == alias {
+			return nil
+		}
+	}
+	log.Printf("[WARN] Removing Mapped Service Alias %q because it's gone", d.Get("id").(string))
+	d.SetId("")
 	return nil
 }
 

--- a/metanetworks/resource_protocol_group.go
+++ b/metanetworks/resource_protocol_group.go
@@ -2,7 +2,6 @@ package metanetworks
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -209,7 +208,6 @@ func flattenProtocols(in []Protocol) []map[string]interface{} {
 		m["proto"] = v.Protocol
 		out[i] = m
 	}
-	log.Printf("flattenProtocols: %s", out)
 	return out
 }
 


### PR DESCRIPTION
This PR fixes an issue with mapped service alias, if they are removed outside of the UI, terraform tries to destroy it and fails, because the resource doesn't exist anymore.