### PR TITLE
fix: remove mapped service alias if mapped_service longers exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this chart adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-pre-2.2] - 2022-03-10
+
+### Fixed
+
+- Destroy `metanetworks_mapped_service_alias` from the state if `mapped_service` is removed outside of terraform
+
 ## [1.0.0-pre-2.1] - 2022-03-10
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 TEST?=$$(go list ./... | grep -v 'vendor')
 HOSTNAME=localhost
-NAMESPACE=mataneine
+NAMESPACE=FabioAntunes
 NAME=metanetworks
 BINARY=terraform-provider-${NAME}
-VERSION=1.0.0-pre-2.1
+VERSION=1.0.0-pre-2.2
 OS_ARCH=darwin_amd64
 
 default: install

--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
-Terraform Provider for Meta Networks
-======================================================
+# Terraform Provider for Meta Networks
 
 See the [Meta Networks Provider documentation](docs/index.md) to get started using the provider.
 
-Requirements
-------------
+## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) 0.12.x or higher
 - [Go](https://golang.org/doc/install) 1.13 (to build the provider plugin)
 - [GOPATH](http://golang.org/doc/code.html#GOPATH)
 
-Building The Provider
----------------------
+## Building The Provider
 
 Clone repository to: `$GOPATH/src/github.com/mataneine/terraform-provider-metanetworks`
 
@@ -27,23 +24,32 @@ $ cd $GOPATH/src/github.com/mataneine/terraform-provider-metanetworks
 $ make build
 ```
 
-Using the provider
-----------------------
+## Using the provider
 
-Enter the provider directory and install the provider
+```terraform
+terraform {
+  required_providers {
+    metanetworks = {
+      source  = "FabioAntunes/metanetworks"
+      version = "1.0.0-pre-2.2"
+    }
+  }
+}
 
-```shell
-$ cd $GOPATH/src/github.com/mataneine/terraform-provider-metanetworks
-$ make install
+provider "metanetworks" {
+  org = "example_organization"
+}
+
+# Example resource configuration
+resource "metanetworks_resource" "example" {
+  # ...
+}
 ```
-If you're building the provider, follow the instructions to [install it as a plugin.](https://www.terraform.io/docs/plugins/basics.html#installing-a-plugin) After placing it into your plugins directory,  run `terraform init` to initialize it.
 
-See the [Meta Networks Provider documentation](docs/index.md) to get started using the provider.
-
-Developing the Provider
----------------------------
+## Developing the Provider
 
 Enter the provider directory.
+
 ```sh
 $ cd $GOPATH/src/github.com/mataneine/terraform-provider-metanetworks
 ```
@@ -54,6 +60,35 @@ To compile the provider, run `make build`. This will build the provider and put 
 $ make build
 ```
 
+To use it locally you can install [this provider as plugin](https://www.terraform.io/docs/plugins/basics.html#installing-a-plugin)
+
+```shell
+$ cd $GOPATH/src/github.com/FabioAntunes/terraform-provider-metanetworks
+$ make install
+```
+
+And then use it on your terraform:
+
+```terraform
+provider "metanetworks" {
+  org = "example_organization"
+}
+
+terraform {
+  required_providers {
+    metanetworks = {
+      source  = "localhost/mataneine/metanetworks"
+      version = "1.0.0-pre-2.2"
+    }
+  }
+}
+
+# Example resource configuration
+resource "metanetworks_resource" "example" {
+  # ...
+}
+```
+
 In order to test the provider, you can simply run `make test`.
 
 ```shell
@@ -62,7 +97,7 @@ $ make test
 
 In order to run the full suite of Acceptance tests, run `make testacc`.
 
-*Note:* Acceptance tests create real resources, and often cost money to run.
+**Note:** Acceptance tests create real resources, and often cost money to run.
 
 ```shell
 $ make testacc

--- a/examples/provider/provider-usage.tf
+++ b/examples/provider/provider-usage.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     metanetworks = {
       source  = "FabioAntunes/metanetworks"
-      version = "1.0.0-alpha"
+      version = "1.0.0-pre-2.2"
     }
   }
 }

--- a/metanetworks/api.go
+++ b/metanetworks/api.go
@@ -4,12 +4,22 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"reflect"
 	"time"
 )
+
+type ApiError struct {
+	Err        error
+	StatusCode int
+}
+
+func (e *ApiError) Error() string {
+	return fmt.Sprintf("%s", e.Err)
+}
 
 // Request ...
 func (c *Client) Request(endpoint, method string, data []byte, contentType string) ([]byte, error) {
@@ -44,7 +54,10 @@ func (c *Client) Request(endpoint, method string, data []byte, contentType strin
 		return nil, err
 	}
 	if resp.StatusCode != 200 {
-		return nil, errors.New(string(body))
+		return nil, &ApiError{
+			StatusCode: resp.StatusCode,
+			Err:        errors.New(string(body)),
+		}
 	}
 
 	log.Printf("Response: %s", body)

--- a/metanetworks/resource_mapped_service_alias.go
+++ b/metanetworks/resource_mapped_service_alias.go
@@ -72,6 +72,12 @@ func resourceMappedServiceAliasRead(d *schema.ResourceData, m interface{}) error
 	var networkElement *NetworkElement
 	networkElement, err := client.GetNetworkElement(mappedServiceID)
 	if err != nil {
+		if apierr, ok := err.(*ApiError); ok && apierr.StatusCode == 404 {
+			log.Printf("[WARN] Removing Mapped Service Alias %q because mapped service %q no longer exists", d.Get("id").(string), mappedServiceID)
+			d.SetId("")
+
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
If a mapped service is removed outside of the terraform state, we need to update the mapped_service_alias as well.