### PR TITLE
fix: wait for mapped_service_alias creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this chart adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-pre-2.3] - 2022-03-10
+
+### Fixed
+
+- Creating `metanetworks_mapped_service_alias` would sometimes produce an inconsistent state
+
 ## [1.0.0-pre-2.2] - 2022-03-10
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=localhost
 NAMESPACE=FabioAntunes
 NAME=metanetworks
 BINARY=terraform-provider-${NAME}
-VERSION=1.0.0-pre-2.2
+VERSION=1.0.0-pre-2.3
 OS_ARCH=darwin_amd64
 
 default: install

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ terraform {
   required_providers {
     metanetworks = {
       source  = "FabioAntunes/metanetworks"
-      version = "1.0.0-pre-2.2"
+      version = "1.0.0-pre-2.3"
     }
   }
 }
@@ -77,8 +77,8 @@ provider "metanetworks" {
 terraform {
   required_providers {
     metanetworks = {
-      source  = "localhost/mataneine/metanetworks"
-      version = "1.0.0-pre-2.2"
+      source  = "localhost/FabioAntunes/metanetworks"
+      version = "1.0.0-pre-2.3"
     }
   }
 }

--- a/examples/provider/provider-usage.tf
+++ b/examples/provider/provider-usage.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     metanetworks = {
       source  = "FabioAntunes/metanetworks"
-      version = "1.0.0-pre-2.2"
+      version = "1.0.0-pre-2.3"
     }
   }
 }

--- a/metanetworks/resource_mapped_service_alias.go
+++ b/metanetworks/resource_mapped_service_alias.go
@@ -58,6 +58,12 @@ func resourceMappedServiceAliasCreate(d *schema.ResourceData, m interface{}) err
 		return err
 	}
 
+	_, err = WaitNetworkElementAliasCreate(client, mappedServiceID, alias)
+
+	if err != nil {
+		return fmt.Errorf("Error waiting for alias attachment creation (%s) (%s)", mappedServiceID, err)
+	}
+
 	d.SetId(fmt.Sprintf("%s_%s", mappedServiceID, alias))
 
 	return resourceMappedServiceAliasRead(d, m)


### PR DESCRIPTION
When creating an alias for a network element we need to wait for the API to return a consistent state.